### PR TITLE
Add support for different AWS authentication types (to `aaronsteers` fork)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,10 @@ This is a [Singer](https://singer.io) tap that produces JSON-formatted data
 following the [Singer
 spec](https://github.com/singer-io/getting-started/blob/master/SPEC.md).
 
+## Configuration
+
+This tap can get it's credentials in a variety of ways, including [environment variables](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#environment-variables), [shared credentials file](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#shared-credentials-file), [AWS config file](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#aws-config-file), [assume role provider](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#assume-role-provider), and [IAM roles](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#iam-roles).
+
+The config file requires `region_name`. You can optionally add `account_id`, `external_id`, and `role_name` to have this tap assume that AWS Role. For testing you can specify `use_local_dynamo` to run against a local instance of [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html).
+
 Copyright &copy; 2019 Stitch

--- a/tap_dynamodb/__init__.py
+++ b/tap_dynamodb/__init__.py
@@ -12,7 +12,7 @@ from tap_dynamodb.sync import sync_stream
 
 LOGGER = singer.get_logger()
 
-REQUIRED_CONFIG_KEYS = ["account_id", "external_id", "role_name", "region_name"]
+REQUIRED_CONFIG_KEYS = ["region_name"]
 
 def do_discover(config):
     LOGGER.info("Starting discover")

--- a/tap_dynamodb/dynamodb.py
+++ b/tap_dynamodb/dynamodb.py
@@ -40,30 +40,31 @@ class AssumeRoleProvider():
 
 @retry_pattern()
 def setup_aws_client(config):
-    role_arn = "arn:aws:iam::{}:role/{}".format(config['account_id'].replace('-', ''),
-                                                config['role_name'])
+    if 'role_name' in config:
+        role_arn = "arn:aws:iam::{}:role/{}".format(config['account_id'].replace('-', ''),
+                                                    config['role_name'])
 
-    session = Session()
-    fetcher = AssumeRoleCredentialFetcher(
-        session.create_client,
-        session.get_credentials(),
-        role_arn,
-        extra_args={
-            'DurationSeconds': 3600,
-            'RoleSessionName': 'TapDynamodDB',
-            'ExternalId': config['external_id']
-        },
-        cache=JSONFileCache()
-    )
+        session = Session()
+        fetcher = AssumeRoleCredentialFetcher(
+            session.create_client,
+            session.get_credentials(),
+            role_arn,
+            extra_args={
+                'DurationSeconds': 3600,
+                'RoleSessionName': 'TapDynamodDB',
+                'ExternalId': config['external_id']
+            },
+            cache=JSONFileCache()
+        )
 
-    refreshable_session = Session()
-    refreshable_session.register_component(
-        'credential_provider',
-        CredentialResolver([AssumeRoleProvider(fetcher)])
-    )
+        refreshable_session = Session()
+        refreshable_session.register_component(
+            'credential_provider',
+            CredentialResolver([AssumeRoleProvider(fetcher)])
+        )
 
-    LOGGER.info("Attempting to assume_role on RoleArn: %s", role_arn)
-    boto3.setup_default_session(botocore_session=refreshable_session)
+        LOGGER.info("Attempting to assume_role on RoleArn: %s", role_arn)
+        boto3.setup_default_session(botocore_session=refreshable_session)
 
 def get_client(config):
     if config.get('use_local_dynamo'):


### PR DESCRIPTION
Adds support for all the different authentication types
the AWS boto library supports, including environment variables,
shared credentials files, and IAM roles.

Also document config options.

# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
